### PR TITLE
🔀 :: 전체 방과후 리스트 responseDTO 수정

### DIFF
--- a/src/main/java/com/msg/after_school/domain/after_school/controller/AfterSchoolController.java
+++ b/src/main/java/com/msg/after_school/domain/after_school/controller/AfterSchoolController.java
@@ -1,8 +1,8 @@
 package com.msg.after_school.domain.after_school.controller;
 
 import com.msg.after_school.domain.after_school.data.dto.CancelApplyAfterSchoolDto;
-import com.msg.after_school.domain.after_school.data.dto.response.AfterSchoolListResponseDto;
-import com.msg.after_school.domain.after_school.data.response.AfterSchoolResponse;
+import com.msg.after_school.domain.after_school.data.dto.response.FindAfterSchoolListResponseDto;
+import com.msg.after_school.domain.after_school.data.dto.response.AfterSchoolResponseDto;
 import com.msg.after_school.domain.after_school.service.AfterSchoolService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,9 +22,9 @@ public class AfterSchoolController {
 
     @GetMapping//방과후 목록을 가져온다.
     @ResponseBody
-    public ResponseEntity<List<AfterSchoolListResponseDto>> findAfterSchoolList() {
+    public ResponseEntity<FindAfterSchoolListResponseDto> findAfterSchoolList() {
         //Request정보를 검색조건 Dto로 치환한다.
-        List<AfterSchoolListResponseDto> dtoList = afterSchoolService.findAfterSchoolList();
+        List<AfterSchoolResponseDto> dtoList = afterSchoolService.findAfterSchoolList();
         //받아온 목록을 응답값으로 치환한다.
         return new ResponseEntity(dtoList, HttpStatus.OK);
     }

--- a/src/main/java/com/msg/after_school/domain/after_school/data/dto/response/AfterSchoolResponseDto.java
+++ b/src/main/java/com/msg/after_school/domain/after_school/data/dto/response/AfterSchoolResponseDto.java
@@ -1,7 +1,5 @@
 package com.msg.after_school.domain.after_school.data.dto.response;
 
-import com.msg.after_school.domain.after_school.data.entity.DayOfWeek;
-import com.msg.after_school.domain.after_school.data.entity.Grade;
 import lombok.*;
 
 import java.util.List;
@@ -11,7 +9,7 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class AfterSchoolListResponseDto {
+public class AfterSchoolResponseDto {
     private Integer id;
     private String title;
     private List<Integer> grade;

--- a/src/main/java/com/msg/after_school/domain/after_school/data/dto/response/FindAfterSchoolListResponseDto.java
+++ b/src/main/java/com/msg/after_school/domain/after_school/data/dto/response/FindAfterSchoolListResponseDto.java
@@ -12,7 +12,7 @@ import java.util.List;
 @NoArgsConstructor
 @Builder
 public class FindAfterSchoolListResponseDto {
-    private List<AfterSchoolResponseDto> lists;
+    private List<AfterSchoolResponseDto> list;
     private Integer currentGrade;
     private List<Integer> appliedGrades;
 }

--- a/src/main/java/com/msg/after_school/domain/after_school/data/dto/response/FindAfterSchoolListResponseDto.java
+++ b/src/main/java/com/msg/after_school/domain/after_school/data/dto/response/FindAfterSchoolListResponseDto.java
@@ -1,0 +1,18 @@
+package com.msg.after_school.domain.after_school.data.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class FindAfterSchoolListResponseDto {
+    private List<AfterSchoolResponseDto> lists;
+    private Integer currentGrade;
+    private List<Integer> appliedGrades;
+}

--- a/src/main/java/com/msg/after_school/domain/after_school/data/dto/response/FindAfterSchoolListResponseDto.java
+++ b/src/main/java/com/msg/after_school/domain/after_school/data/dto/response/FindAfterSchoolListResponseDto.java
@@ -14,5 +14,5 @@ import java.util.List;
 public class FindAfterSchoolListResponseDto {
     private List<AfterSchoolResponseDto> list;
     private Integer currentGrade;
-    private List<Integer> appliedGrades;
+    private List<String> appliedWeek;
 }

--- a/src/main/java/com/msg/after_school/domain/after_school/service/AfterSchoolService.java
+++ b/src/main/java/com/msg/after_school/domain/after_school/service/AfterSchoolService.java
@@ -1,13 +1,13 @@
 package com.msg.after_school.domain.after_school.service;
 
 
-import com.msg.after_school.domain.after_school.data.dto.response.AfterSchoolListResponseDto;
-import com.msg.after_school.domain.after_school.data.entity.AfterSchool;
+import com.msg.after_school.domain.after_school.data.dto.response.AfterSchoolResponseDto;
+import com.msg.after_school.domain.after_school.data.dto.response.FindAfterSchoolListResponseDto;
 
 import java.util.List;
 
 public interface AfterSchoolService {
-    List<AfterSchoolListResponseDto> findAfterSchoolList();
+    FindAfterSchoolListResponseDto findAfterSchoolList();
 
     void applyAfterSchool(Integer AfterSchoolId);
 

--- a/src/main/java/com/msg/after_school/domain/after_school/service/impl/AfterSchoolServiceImpl.java
+++ b/src/main/java/com/msg/after_school/domain/after_school/service/impl/AfterSchoolServiceImpl.java
@@ -55,24 +55,24 @@ public class AfterSchoolServiceImpl implements AfterSchoolService {
 
         Integer currentGrade = currentUser.getGrade();
 
-        List<Integer> allAppliedGrades = appliedAfterSchoolList.stream()
-                .map(AfterSchool::getGrade)
-                .reduce((grade1, grade2) -> {
-                    grade1.addAll(grade2);
-                    return grade1;
+        List<String> allAppliedWeek = appliedAfterSchoolList.stream()
+                .map(AfterSchool::getDayOfWeek)
+                .reduce((week1, week2) -> {
+                    week1.addAll(week2);
+                    return week1;
                 })
                 .orElse(List.of()).stream()
-                .map(Grade::getGrade)
+                .map(DayOfWeek::getDayOfWeek)
                 .collect(Collectors.toList());
 
-        HashSet<Integer> settedGrades = new HashSet<>(allAppliedGrades);
+        HashSet<String> setWeek = new HashSet<>(allAppliedWeek);
 
-        List<Integer> appliedGrades = Arrays.asList((Integer[]) settedGrades.toArray());
+        List<String> appliedWeek = Arrays.asList((String[]) setWeek.toArray());
 
         return FindAfterSchoolListResponseDto.builder()
                 .list(afterSchoolListResponseDtoList)
                 .currentGrade(currentGrade)
-                .appliedGrades(appliedGrades)
+                .appliedWeek(appliedWeek)
                 .build();
     }
 

--- a/src/main/java/com/msg/after_school/domain/after_school/service/impl/AfterSchoolServiceImpl.java
+++ b/src/main/java/com/msg/after_school/domain/after_school/service/impl/AfterSchoolServiceImpl.java
@@ -57,12 +57,14 @@ public class AfterSchoolServiceImpl implements AfterSchoolService {
 
         List<String> appliedWeek = Arrays.asList((String[]) appliedAfterSchoolList.stream()
                 .map(AfterSchool::getDayOfWeek)
-                .reduce((week1, week2) -> {
+                .reduce(List.of(),(week1, week2) -> {
                     week1.addAll(week2);
                     return week1;
-                })
-                .orElse(List.of()).stream()
-                .map(DayOfWeek::getDayOfWeek).distinct().toArray());
+                }).stream()
+                .map(DayOfWeek::getDayOfWeek)
+                .distinct()
+                .toArray()
+        );
 
         return FindAfterSchoolListResponseDto.builder()
                 .list(afterSchoolListResponseDtoList)

--- a/src/main/java/com/msg/after_school/domain/after_school/service/impl/AfterSchoolServiceImpl.java
+++ b/src/main/java/com/msg/after_school/domain/after_school/service/impl/AfterSchoolServiceImpl.java
@@ -55,19 +55,14 @@ public class AfterSchoolServiceImpl implements AfterSchoolService {
 
         Integer currentGrade = currentUser.getGrade();
 
-        List<String> allAppliedWeek = appliedAfterSchoolList.stream()
+        List<String> appliedWeek = Arrays.asList((String[]) appliedAfterSchoolList.stream()
                 .map(AfterSchool::getDayOfWeek)
                 .reduce((week1, week2) -> {
                     week1.addAll(week2);
                     return week1;
                 })
                 .orElse(List.of()).stream()
-                .map(DayOfWeek::getDayOfWeek)
-                .collect(Collectors.toList());
-
-        HashSet<String> setWeek = new HashSet<>(allAppliedWeek);
-
-        List<String> appliedWeek = Arrays.asList((String[]) setWeek.toArray());
+                .map(DayOfWeek::getDayOfWeek).distinct().toArray());
 
         return FindAfterSchoolListResponseDto.builder()
                 .list(afterSchoolListResponseDtoList)

--- a/src/main/java/com/msg/after_school/domain/after_school/service/impl/AfterSchoolServiceImpl.java
+++ b/src/main/java/com/msg/after_school/domain/after_school/service/impl/AfterSchoolServiceImpl.java
@@ -70,7 +70,7 @@ public class AfterSchoolServiceImpl implements AfterSchoolService {
         List<Integer> appliedGrades = Arrays.asList((Integer[]) settedGrades.toArray());
 
         return FindAfterSchoolListResponseDto.builder()
-                .lists(afterSchoolListResponseDtoList)
+                .list(afterSchoolListResponseDtoList)
                 .currentGrade(currentGrade)
                 .appliedGrades(appliedGrades)
                 .build();


### PR DESCRIPTION
# 개요
대충 원래는 전체 리스트만 오던거에 보낸 유저의 학년이랑 신청한 요일을 반환?

# 수정사항
```json
{
    "list": [
			{
        "id": 1,
        "title": "DB",
        "week": [
            "MON"
        ],
        "grade": [
            1
        ],
        "isOpened": true,
				"isApplied": true
	    },
	    {
        "id": 2,
        "title": "응애",
        "week": [
            "MON"
        ],
        "grade": [
            1
        ],
        "isOpened": true,
				"isApplied": false
	    },
	    {
        "id": 3,
        "title": "햄버거",
        "week": [
            "TUE"
        ],
        "grade": [
            1
        ],
        "isOpened": true,
				"isApplied": false
	    }
		],
		"currentGrade": 2,
		"appliedWeek": ["MON", "TUE"]
}
```